### PR TITLE
Partially fix performance issue when loading super large text into one single paragraph when RichText control is enabled with styles

### DIFF
--- a/Source/Controls/TextEditorPackage/GuiDocumentCommonInterface.cpp
+++ b/Source/Controls/TextEditorPackage/GuiDocumentCommonInterface.cpp
@@ -715,21 +715,38 @@ GuiDocumentCommonInterface
 
 			void GuiDocumentCommonInterface::UserInput_JoinLinesInsideParagraph(WString& text)
 			{
+				const wchar_t* buffer = text.Buffer();
+				const wchar_t* begin = buffer;
+				const wchar_t* end = begin;
+				const wchar_t* next = nullptr;
+				
+				while (*end != '\r' && *end != '\n' && *end != '\0') end++;
+				next = end;
+				while (*next != '\n' && *next != '\0') next++;
+				if (!*next)
+				{
+					text = text.Left(end - begin);
+					return;
+				}
+
 				text = stream::GenerateToStream([&](stream::StreamWriter& writer)
 				{
-					for (vint j = 0; j < text.Length(); j++)
+					writer.WriteString(text.Left(end - begin));
+					while (!*next)
 					{
-						if (text[j] == L'\n')
+						if (config.spaceForFlattenedLineBreak)
 						{
-							if (config.spaceForFlattenedLineBreak)
-							{
-								writer.WriteChar(L' ');
-							}
+							writer.WriteChar(L' ');
 						}
-						else if (text[j] != L'\r')
-						{
-							writer.WriteChar(text[j]);
-						}
+
+						begin = next;
+						end = begin;
+						next = nullptr;
+
+						while (*end != '\r' && *end != '\n' && *end != '\0') end++;
+						next = end;
+						while (*next != '\n' && *next != '\0') next++;
+						writer.WriteString(text.Left(end - begin));
 					}
 				});
 			}

--- a/Source/Controls/TextEditorPackage/GuiDocumentCommonInterface.cpp
+++ b/Source/Controls/TextEditorPackage/GuiDocumentCommonInterface.cpp
@@ -662,7 +662,7 @@ GuiDocumentCommonInterface
 
 			//================ basic
 
-			void GuiDocumentCommonInterface::UserInput_FixForPlainText(Ptr<DocumentModel> model, vint beginParagraph, vint endParagraph)
+			void GuiDocumentCommonInterface::UserInput_ConvertToPlainText(Ptr<DocumentModel> model, vint beginParagraph, vint endParagraph)
 			{
 				if (beginParagraph > endParagraph) return;
 
@@ -679,7 +679,7 @@ GuiDocumentCommonInterface
 				}
 			}
 
-			void GuiDocumentCommonInterface::UserInput_FixForSingleline(collections::List<WString>& paragraphTexts)
+			void GuiDocumentCommonInterface::UserInput_JoinParagraphs(collections::List<WString>& paragraphTexts)
 			{
 				auto line = stream::GenerateToStream([&](stream::StreamWriter& writer)
 				{
@@ -696,7 +696,7 @@ GuiDocumentCommonInterface
 				paragraphTexts.Add(line);
 			}
 
-			void GuiDocumentCommonInterface::UserInput_FixForSingleline(Ptr<DocumentModel> model)
+			void GuiDocumentCommonInterface::UserInput_JoinParagraphs(Ptr<DocumentModel> model)
 			{
 				auto firstParagraph = model->paragraphs[0];
 				for (auto paragraph : From(model->paragraphs).Skip(1))
@@ -713,7 +713,7 @@ GuiDocumentCommonInterface
 				model->paragraphs.Add(firstParagraph);
 			}
 
-			void GuiDocumentCommonInterface::UserInput_FixForNonParagraph(WString& text)
+			void GuiDocumentCommonInterface::UserInput_JoinLinesInsideParagraph(WString& text)
 			{
 				text = stream::GenerateToStream([&](stream::StreamWriter& writer)
 				{
@@ -734,7 +734,7 @@ GuiDocumentCommonInterface
 				});
 			}
 
-			void GuiDocumentCommonInterface::UserInput_FixForNonParagraph(Ptr<DocumentParagraphRun> paragraph)
+			void GuiDocumentCommonInterface::UserInput_JoinLinesInsideParagraph(Ptr<DocumentParagraphRun> paragraph)
 			{
 				List<Ptr<DocumentContainerRun>> containers;
 				containers.Add(paragraph);
@@ -750,7 +750,7 @@ GuiDocumentCommonInterface
 						}
 						else if (auto textRun = run.Cast<DocumentTextRun>())
 						{
-							UserInput_FixForNonParagraph(textRun->text);
+							UserInput_JoinLinesInsideParagraph(textRun->text);
 						}
 					}
 				}
@@ -767,12 +767,12 @@ GuiDocumentCommonInterface
 				{
 					for (vint i = 0; i < paragraphTexts.Count(); i++)
 					{
-						UserInput_FixForNonParagraph(paragraphTexts[i]);
+						UserInput_JoinLinesInsideParagraph(paragraphTexts[i]);
 					}
 				}
 				if (config.paragraphMode == GuiDocumentParagraphMode::Singleline)
 				{
-					UserInput_FixForSingleline(paragraphTexts);
+					UserInput_JoinParagraphs(paragraphTexts);
 				}
 			}
 
@@ -830,7 +830,7 @@ GuiDocumentCommonInterface
 				}
 				if (config.paragraphMode == GuiDocumentParagraphMode::Singleline)
 				{
-					UserInput_FixForSingleline(paragraphTexts);
+					UserInput_JoinParagraphs(paragraphTexts);
 				}
 			}
 
@@ -839,7 +839,7 @@ GuiDocumentCommonInterface
 				if (!model) return;
 				if (config.pasteAsPlainText)
 				{
-					UserInput_FixForPlainText(model, 0, model->paragraphs.Count() - 1);
+					UserInput_ConvertToPlainText(model, 0, model->paragraphs.Count() - 1);
 
 					if (baselineDocument)
 					{
@@ -860,12 +860,12 @@ GuiDocumentCommonInterface
 				{
 					for (auto paragraph : model->paragraphs)
 					{
-						UserInput_FixForNonParagraph(paragraph);
+						UserInput_JoinLinesInsideParagraph(paragraph);
 					}
 				}
 				if (config.paragraphMode == GuiDocumentParagraphMode::Singleline)
 				{
-					UserInput_FixForSingleline(model);
+					UserInput_JoinParagraphs(model);
 				}
 			}
 
@@ -995,7 +995,7 @@ GuiDocumentCommonInterface
 					{
 						if(!skipFormatting)
 						{
-							UserInput_FixForPlainText(model, index, index + newCount - 1);
+							UserInput_ConvertToPlainText(model, index, index + newCount - 1);
 						}
 						if (baselineDocument)
 						{
@@ -1011,7 +1011,7 @@ GuiDocumentCommonInterface
 					{
 						for (vint i = index; i < index + newCount; i++)
 						{
-							UserInput_FixForNonParagraph(model->paragraphs[i]);
+							UserInput_JoinLinesInsideParagraph(model->paragraphs[i]);
 						}
 					}
 

--- a/Source/Controls/TextEditorPackage/GuiDocumentCommonInterface.cpp
+++ b/Source/Controls/TextEditorPackage/GuiDocumentCommonInterface.cpp
@@ -1022,7 +1022,7 @@ GuiDocumentCommonInterface
 
 			void GuiDocumentCommonInterface::EditRun(TextPos begin, TextPos end, Ptr<DocumentModel> model, bool copy, bool skipFormatting)
 			{
-				if (skipFormatting)
+				if (!skipFormatting)
 				{
 					UserInput_FormatDocument(model);
 				}

--- a/Source/Controls/TextEditorPackage/GuiDocumentCommonInterface.h
+++ b/Source/Controls/TextEditorPackage/GuiDocumentCommonInterface.h
@@ -12,7 +12,6 @@ Interfaces:
 #include "GuiDocumentConfig.h"
 #include "EditorCallback/GuiTextUndoRedo.h"
 #include "../GuiContainerControls.h"
-#include "../../GraphicsElement/GuiGraphicsDocumentRenderer.h"
 
 namespace vl
 {

--- a/Source/Controls/TextEditorPackage/GuiDocumentCommonInterface.h
+++ b/Source/Controls/TextEditorPackage/GuiDocumentCommonInterface.h
@@ -129,18 +129,20 @@ GuiDocumentCommonInterface
 				void										OnFinishRender()override;
 				Size										OnRenderEmbeddedObject(const WString& name, const Rect& location)override;
 
+			public:
+
+				static void									UserInput_ConvertToPlainText(Ptr<DocumentModel> model, vint beginParagraph, vint endParagraph);
+				static void									UserInput_JoinParagraphs(collections::List<WString>& paragraphTexts, bool spaceForFlattenedLineBreak);
+				static void									UserInput_JoinParagraphs(Ptr<DocumentModel> model, bool spaceForFlattenedLineBreak);
+				static void									UserInput_JoinLinesInsideParagraph(WString& text, bool spaceForFlattenedLineBreak);
+				static void									UserInput_JoinLinesInsideParagraph(Ptr<DocumentParagraphRun> paragraph, bool spaceForFlattenedLineBreak);
+				static void									UserInput_FormatText(collections::List<WString>& paragraphTexts, const GuiDocumentConfigEvaluated& config);
+				static void									UserInput_FormatText(const WString& text, collections::List<WString>& paragraphTexts, const GuiDocumentConfigEvaluated& config);
+				static void									UserInput_FormatDocument(Ptr<DocumentModel> model, Ptr<DocumentModel> baselineDocument, const GuiDocumentConfigEvaluated& config);
+
 			protected:
 
-				void										UserInput_ConvertToPlainText(Ptr<DocumentModel> model, vint beginParagraph, vint endParagraph);
-				void										UserInput_JoinParagraphs(collections::List<WString>& paragraphTexts);
-				void										UserInput_JoinParagraphs(Ptr<DocumentModel> model);
-				void										UserInput_JoinLinesInsideParagraph(WString& text);
-				void										UserInput_JoinLinesInsideParagraph(Ptr<DocumentParagraphRun> paragraph);
-
 				WString										UserInput_ConvertDocumentToText(Ptr<DocumentModel> model);
-				void										UserInput_FormatText(collections::List<WString>& paragraphTexts);
-				void										UserInput_FormatText(const WString& text, collections::List<WString>& paragraphTexts);
-				void										UserInput_FormatDocument(Ptr<DocumentModel> model);
 
 			public:
 				GuiDocumentCommonInterface(const GuiDocumentConfig& _config);

--- a/Source/Controls/TextEditorPackage/GuiDocumentCommonInterface.h
+++ b/Source/Controls/TextEditorPackage/GuiDocumentCommonInterface.h
@@ -131,11 +131,11 @@ GuiDocumentCommonInterface
 
 			protected:
 
-				void										UserInput_FixForPlainText(Ptr<DocumentModel> model, vint beginParagraph, vint endParagraph);
-				void										UserInput_FixForSingleline(collections::List<WString>& paragraphTexts);
-				void										UserInput_FixForSingleline(Ptr<DocumentModel> model);
-				void										UserInput_FixForNonParagraph(WString& text);
-				void										UserInput_FixForNonParagraph(Ptr<DocumentParagraphRun> paragraph);
+				void										UserInput_ConvertToPlainText(Ptr<DocumentModel> model, vint beginParagraph, vint endParagraph);
+				void										UserInput_JoinParagraphs(collections::List<WString>& paragraphTexts);
+				void										UserInput_JoinParagraphs(Ptr<DocumentModel> model);
+				void										UserInput_JoinLinesInsideParagraph(WString& text);
+				void										UserInput_JoinLinesInsideParagraph(Ptr<DocumentParagraphRun> paragraph);
 
 				WString										UserInput_ConvertDocumentToText(Ptr<DocumentModel> model);
 				void										UserInput_FormatText(collections::List<WString>& paragraphTexts);

--- a/Source/GraphicsElement/GuiGraphicsDocumentRenderer.cpp
+++ b/Source/GraphicsElement/GuiGraphicsDocumentRenderer.cpp
@@ -496,7 +496,6 @@ GuiDocumentParagraphCache
 					}
 					else
 					{
-						if (index > paragraphSizes.Count() - 1) return paragraphSizes.Count() - 1;
 						start = validCachedTops;
 					}
 				}

--- a/Source/GraphicsElement/GuiGraphicsDocumentRenderer.h
+++ b/Source/GraphicsElement/GuiGraphicsDocumentRenderer.h
@@ -42,8 +42,10 @@ GuiDocumentParagraphCache
 
 				struct ParagraphCache
 				{
-					WString								fullText;
 					Ptr<IGuiGraphicsParagraph>			graphicsParagraph;
+					bool								outdatedStyles = true;
+
+					WString								fullText;
 					IdEmbeddedObjectMap					embeddedObjects;
 					vint								selectionBegin = -1;
 					vint								selectionEnd = -1;

--- a/Source/PlatformProviders/Windows/Direct2D/Renderers/GuiGraphicsLayoutProviderWindowsDirect2D.cpp
+++ b/Source/PlatformProviders/Windows/Direct2D/Renderers/GuiGraphicsLayoutProviderWindowsDirect2D.cpp
@@ -543,11 +543,11 @@ WindowsDirect2DParagraph (Formatting)
 
 				void SetMaxWidth(vint value)override
 				{
-					if(maxWidth!=value)
+					if (maxWidth != value)
 					{
-						maxWidth=value;
-						textLayout->SetMaxWidth(value==-1?65536:(FLOAT)value);
-						formatDataAvailable=false;
+						maxWidth = value;
+						textLayout->SetMaxWidth(value == -1 ? 65536 : (FLOAT)value);
+						formatDataAvailable = false;
 					}
 				}
 
@@ -568,18 +568,21 @@ WindowsDirect2DParagraph (Formatting)
 
 				void SetParagraphAlignment(Alignment value)override
 				{
-					formatDataAvailable=false;
-					switch(value)
+					if (GetParagraphAlignment() != value)
 					{
-					case Alignment::Left:
-						textLayout->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING);
-						break;
-					case Alignment::Center:
-						textLayout->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
-						break;
-					case Alignment::Right:
-						textLayout->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_TRAILING);
-						break;
+						formatDataAvailable = false;
+						switch (value)
+						{
+						case Alignment::Left:
+							textLayout->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING);
+							break;
+						case Alignment::Center:
+							textLayout->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+							break;
+						case Alignment::Right:
+							textLayout->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_TRAILING);
+							break;
+						}
 					}
 				}
 

--- a/Source/PlatformProviders/Windows/GDI/Renderers/GuiGraphicsLayoutProviderWindowsGDI.cpp
+++ b/Source/PlatformProviders/Windows/GDI/Renderers/GuiGraphicsLayoutProviderWindowsGDI.cpp
@@ -98,8 +98,11 @@ WindowsGDIParagraph
 
 				void SetWrapLine(bool value)override
 				{
-					paragraph->BuildUniscribeData(renderTarget->GetDC());
-					paragraph->Layout(value, paragraph->lastAvailableWidth, paragraph->paragraphAlignment);
+					if (paragraph->lastWrapLine != value)
+					{
+						paragraph->BuildUniscribeData(renderTarget->GetDC());
+						paragraph->Layout(value, paragraph->lastAvailableWidth, paragraph->paragraphAlignment);
+					}
 				}
 
 				vint GetMaxWidth()override
@@ -109,8 +112,11 @@ WindowsGDIParagraph
 
 				void SetMaxWidth(vint value)override
 				{
-					paragraph->BuildUniscribeData(renderTarget->GetDC());
-					paragraph->Layout(paragraph->lastWrapLine, value, paragraph->paragraphAlignment);
+					if (paragraph->lastAvailableWidth != value)
+					{
+						paragraph->BuildUniscribeData(renderTarget->GetDC());
+						paragraph->Layout(paragraph->lastWrapLine, value, paragraph->paragraphAlignment);
+					}
 				}
 
 				Alignment GetParagraphAlignment()override
@@ -120,8 +126,11 @@ WindowsGDIParagraph
 
 				void SetParagraphAlignment(Alignment value)override
 				{
-					paragraph->BuildUniscribeData(renderTarget->GetDC());
-					paragraph->Layout(paragraph->lastWrapLine, paragraph->lastAvailableWidth, value);
+					if (paragraph->paragraphAlignment != value)
+					{
+						paragraph->BuildUniscribeData(renderTarget->GetDC());
+						paragraph->Layout(paragraph->lastWrapLine, paragraph->lastAvailableWidth, value);
+					}
 				}
 
 				bool SetFont(vint start, vint length, const WString& value)override

--- a/Test/GacUISrc/Playground/Main.cpp
+++ b/Test/GacUISrc/Playground/Main.cpp
@@ -143,7 +143,7 @@ void GuiMain()
 	LoadPlaygroundTypes();
 
 	List<WString> names;
-	names.Add(L"ResourceBigJson");
+	names.Add(L"ResourceDocument");
 
 	Group<WString, WString> deps;
 

--- a/ToDo/1.3.0.0.md
+++ b/ToDo/1.3.0.0.md
@@ -49,6 +49,8 @@
     - Using `MemoryStream` directly instead of string concat.
   - Add a new option `paragraphRecycle`, when it is true, a `IGuiGraphicsParagraph` outside of the view will be released, keeping only the last height.
     - This option will be enabled by default.
+- `GuiDocumentCommonInterface` testability
+  - Make `UserInput_` methods public static and run unit test.
 - Document
   - `GuiSinglelineTextBox` and `GuiMultilineTextBox`
     - `Select` -> `SetCaret`

--- a/ToDo/1.3.0.0.md
+++ b/ToDo/1.3.0.0.md
@@ -38,6 +38,8 @@
 - UnitTestSnapshotViewer
   - It becomes slow when loading a large test case like `Test\Resources\UnitTestSnapshots\Controls\Ribbon\GuiRibbonButtons\Dropdowns.json`.
   - `UnitTestSnapshotFileNode::EnsureLoaded`, `JsonParse` takes too much time.
+- FileDialog
+  - No file showing if filtered, see `CppTest` for insert image dialog.
 
 ## Milestone
 
@@ -47,7 +49,6 @@
     - Using `MemoryStream` directly instead of string concat.
   - Add a new option `paragraphRecycle`, when it is true, a `IGuiGraphicsParagraph` outside of the view will be released, keeping only the last height.
     - This option will be enabled by default.
-  - In `GetParagraphFromY` the paragraph height must include `paragraphDistance` in binary search. Fix the third branch to check the last paragraph index.
 - Document
   - `GuiSinglelineTextBox` and `GuiMultilineTextBox`
     - `Select` -> `SetCaret`

--- a/ToDo/1.3.0.0.md
+++ b/ToDo/1.3.0.0.md
@@ -47,7 +47,7 @@
     - Using `MemoryStream` directly instead of string concat.
   - Add a new option `paragraphRecycle`, when it is true, a `IGuiGraphicsParagraph` outside of the view will be released, keeping only the last height.
     - This option will be enabled by default.
-  - In `GetParagraphFromY` the paragraph height must include `paragraphDistance` in binary search.
+  - In `GetParagraphFromY` the paragraph height must include `paragraphDistance` in binary search. Fix the third branch to check the last paragraph index.
 - Document
   - `GuiSinglelineTextBox` and `GuiMultilineTextBox`
     - `Select` -> `SetCaret`

--- a/ToDo/1.3.0.0.md
+++ b/ToDo/1.3.0.0.md
@@ -14,6 +14,17 @@
 - `GuiDocumentCommonInterface` offer `ConvertToPlainText` and `LoadTextAndClearUndoRedo`/`LoadDocumentAndClearUndoRedo`
 - Add `PasswordChar` to `GuiDocumentCommonInterface`, set to `\0` to disable.
 
+## Known Issues
+
+- `GuiDocumentViewer` loading super large text without empty line (~0.2M lines) too slow
+  - Demo: `https://github.com/vczh-libraries/GacUI/blob/master/Test/Resources/UnitTestSnapshots/Controls/Ribbon/GuiRibbonButtons/Dropdowns.json`
+  - Paragraph mode plus no empty line causing the whole text loaded into one single `IGuiGraphicsParagraph`.
+  - Root cause in `IDWriteTextLayout::GetMetrics`, taking most of the time.
+  - When loading super big content to the control while you don't need user to undo to the previous state:
+    - To load such text into `GuiMultilineTextBox` uses `LoadTextAndClearUndoRedo`.
+    - To load prepared large document into `GuiDocumentViewer` uses `LoadDocumentAndClearUndoRedo`.
+    - Future editing still work with undo.
+
 ## Copilot
 
 - `kb-design.prompt.md`:
@@ -30,11 +41,6 @@
 
 ## Known Issues
 
-- `GuiMultilineTextBox`
-  - It becomes slow when loading huge amount of text like `Test\Resources\UnitTestSnapshots\Controls\Ribbon\GuiRibbonButtons\Dropdowns.json`.
-    - Paragraph mode performance will be unacceptable because:
-      - the whole text is loaded into one single `IGuiGraphicsParagraph`.
-      - `GuiDocumentCommonInterface::UserInput_FormatText` takes too long (in `config.doubleLineBreaksBetweenParagraph`).
 - UnitTestSnapshotViewer
   - It becomes slow when loading a large test case like `Test\Resources\UnitTestSnapshots\Controls\Ribbon\GuiRibbonButtons\Dropdowns.json`.
   - `UnitTestSnapshotFileNode::EnsureLoaded`, `JsonParse` takes too much time.
@@ -44,9 +50,7 @@
 ## Milestone
 
 - Make a general framework for `InjectXXXImpl` and `IXXXImpl`, so that each injected implementation could access the previous implementation, and ensured ejection in order. An ejection could happen in any level so that all dependents are ejected.
-- `GuiDocumentElementRenderer` performance issue
-  - Rewrite all `UserInput_` functions for text processor.
-    - Using `MemoryStream` directly instead of string concat.
+- `GuiDocumentElementRenderer`
   - Add a new option `paragraphRecycle`, when it is true, a `IGuiGraphicsParagraph` outside of the view will be released, keeping only the last height.
     - This option will be enabled by default.
 - `GuiDocumentCommonInterface` testability

--- a/ToDo/1.3.0.0.md
+++ b/ToDo/1.3.0.0.md
@@ -47,6 +47,7 @@
     - Using `MemoryStream` directly instead of string concat.
   - Add a new option `paragraphRecycle`, when it is true, a `IGuiGraphicsParagraph` outside of the view will be released, keeping only the last height.
     - This option will be enabled by default.
+  - In `GetParagraphFromY` the paragraph height must include `paragraphDistance` in binary search.
 - Document
   - `GuiSinglelineTextBox` and `GuiMultilineTextBox`
     - `Select` -> `SetCaret`

--- a/ToDo/KnownIssues.md
+++ b/ToDo/KnownIssues.md
@@ -25,6 +25,11 @@
   - `delete this;` eventually calls `SuspendThread` on the thread itself, making all following clean up code skipped.
   - Windows confirmed, Linux need to test.
 - TODO in `GuiRemoteWindow::OnControllerConnect`.
+- `GuiDocumentViewer`
+  - Loading super large text without empty line (~0.2M lines) too slow
+    - Demo: `Test\Resources\UnitTestSnapshots\Controls\Ribbon\GuiRibbonButtons\Dropdowns.json`
+    - Paragraph mode plus no empty line causing the whole text loaded into one single `IGuiGraphicsParagraph`.
+    - Root cause in `IDWriteTextLayout::GetMetrics`, taking most of the time.
 
 ## Remote Protocol
 - `GuiRemoteGraphicsRenderTarget::fontHeights` could be moved to `GuiRemoteGraphicsResourceManager` as the measuring should not be different.


### PR DESCRIPTION
## Known Issue that out of my current release scope

- `GuiDocumentViewer` loading super large text without empty line (~0.2M lines) too slow
  - Demo: `https://github.com/vczh-libraries/GacUI/blob/master/Test/Resources/UnitTestSnapshots/Controls/Ribbon/GuiRibbonButtons/Dropdowns.json`
  - Paragraph mode plus no empty line causing the whole text loaded into one single `IGuiGraphicsParagraph`.
  - Root cause in `IDWriteTextLayout::GetMetrics`, taking most of the time.
  - When loading super big content to the control while you don't need user to undo to the previous state:
    - To load such text into `GuiMultilineTextBox` uses `LoadTextAndClearUndoRedo`.
    - To load prepared large document into `GuiDocumentViewer` uses `LoadDocumentAndClearUndoRedo`.
    - Future editing still work with undo.

Unless future optimization to be done to make each paragraph splits into multiple `IDWriteTextLayout`.